### PR TITLE
パンくず機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,4 @@ gem 'gon'
 
 gem 'fog-aws'
 
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
       i18n (>= 0.7)
       multi_json
       request_store (>= 1.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -368,6 +370,7 @@ DEPENDENCIES
   fog-aws
   font-awesome-sass
   gon
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -176,7 +176,7 @@
             padding: 6px 10px;
             border-radius: 40px;
             color: #333;
-            // border: 1px solid #333;
+            border: 1px solid #f5f5f5;
             background-color: #f5f5f5;
             cursor: pointer;
           }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@
 @import 'items_new';
 @import 'devise/registrations/new';
 @import 'devise/sessions/new';
+@import 'breadcrumbs';

--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -1,0 +1,28 @@
+.breadcrumbs {
+  border-top: 1px solid #eee;
+  background-color: #fff;
+  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  position: relative;
+
+  &__main {
+    margin: 0 auto;
+    padding: 16px 0;
+    width: 1020px;
+
+    &__body {
+      line-height: 1.2;
+      font-size: 14px;
+      color: #353535;
+
+      a {
+        display: inline-block;
+        margin: 0 6px;
+      }
+
+      .current {
+        font-weight: 600;
+        margin-left: 6px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -17,6 +17,10 @@
       a {
         display: inline-block;
         margin: 0 6px;
+        &:hover {
+          opacity: 0.7;
+          text-decoration: underline;
+        }
       }
 
       .current {

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :new_card
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     .container_contents_main

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :my_card
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     .container_contents_main

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,9 @@
+- if @item.buyer_id.present? && @item.user_id == current_user.id
+  - breadcrumb :my_item, @item
+  = render partial: "layouts/breadcrumbs"
+- elsif @item.buyer_id.present? && @item.buyer_id == current_user.id
+  - breadcrumb :my_purchased_item, @item
+  = render partial: "layouts/breadcrumbs"
 .show-wrapper
   .show-main
     .show-main__contents

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,4 @@
+.breadcrumbs
+  %ul.breadcrumbs__main
+    %li.breadcrumbs__main__body
+      = breadcrumbs separator:  "         > ", class: "breadcrumbs-list"

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,4 +1,4 @@
 .breadcrumbs
   %ul.breadcrumbs__main
     %li.breadcrumbs__main__body
-      = breadcrumbs separator:  "         > ", class: "breadcrumbs-list"
+      = breadcrumbs separator: " ＞ ", class: "breadcrumbs-list"

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :new_profile
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     .container_contents_main
@@ -5,22 +7,4 @@
         .container_contents_main_address_inside
           = link_to "本人確認情報を登録する", step1_profiles_path, method: :get, class: "container_contents_main_address_inside_bottun"
       
-    .container_contents_side
-      .container_contents_side_title
-        設定
-      %ul.container_contents_side_contents
-        %li
-          = link_to "プロフィール","#"
-          .container_contents_side_contents_profile_right
-        %li
-          = link_to "本人確認情報", new_profile_path
-          .container_contents_side_contents_address_right
-        %li
-          = link_to "支払い方法", card_page_path
-          .container_contents_side_contents_card_right
-        %li
-          = link_to "メール / パスワード","#"
-          .container_contents_side_contents_mailpass_right
-        %li
-          = link_to "ログアウト", logout_path, class: "container_contents_side_contents_logout"
-          .container_contents_side_contents_logout_right
+    = render partial: "users/side-bar"

--- a/app/views/sessions/logout_page.html.haml
+++ b/app/views/sessions/logout_page.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :logout
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     .container_contents_main

--- a/app/views/users/my_favorites.html.haml
+++ b/app/views/users/my_favorites.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :my_favorites
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     #items.container_contents_main

--- a/app/views/users/my_items.html.haml
+++ b/app/views/users/my_items.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :my_items
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     #items.container_contents_main

--- a/app/views/users/my_purchased_items.html.haml
+++ b/app/views/users/my_purchased_items.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :my_purchased_items
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     #items.container_contents_main

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :my_page
+= render partial: "layouts/breadcrumbs"
 .container
   .container_contents
     .container_contents_main

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -22,9 +22,19 @@ crumb :my_items do
   parent :my_page
 end
 
+crumb :my_item do |item|
+  link '出品商品画面', item_path(item.id)
+  parent :my_items
+end
+
 crumb :my_purchased_items do
   link '購入した商品', my_purchased_items_users_path
   parent :my_page
+end
+
+crumb :my_purchased_item do |item|
+  link '購入商品画面', item_path(item.id)
+  parent :my_purchased_items
 end
 
 crumb :new_card do

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,59 @@
+crumb :root do
+  link "FURIMA", root_path
+end
+
+crumb :my_page do
+  link "マイページ", user_path(current_user.id)
+  parent :root
+end
+
+crumb :new_profile do
+  link '本人確認情報', new_profile_path
+  parent :my_page
+end
+
+crumb :my_favorites do
+  link 'お気に入り', my_favorites_users_path
+  parent :my_page
+end
+
+crumb :my_items do
+  link '出品した商品', my_items_users_path
+  parent :my_page
+end
+
+crumb :my_purchased_items do
+  link '購入した商品', my_purchased_items_users_path
+  parent :my_page
+end
+
+crumb :new_card do
+  link '支払い方法', new_card_path
+  parent :my_page
+end
+
+crumb :my_card do
+  link '支払い方法', card_path(current_user.id)
+  parent :my_page
+end
+
+crumb :logout do
+  link 'ログアウト', logout_path
+  parent :my_page
+end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
## What
- ユーザーの画面遷移履歴を段階的にし表示し、現在地をわかりやすくした
- 現時点ではマイページと、そこから飛べるページにのみ反映させている。カテゴリ機能との兼ね合いで今後も反映ページを増やしていく予定
## Why
- ユーザーの現在地をわかりやすくするため